### PR TITLE
FizzySteamyMirror.cs - Added HelpUrl

### DIFF
--- a/FizzySteamyMirror.cs
+++ b/FizzySteamyMirror.cs
@@ -3,6 +3,7 @@ using Mirror;
 using FizzySteam;
 using Steamworks;
 
+[HelpURL("https://vis2k.github.io/Mirror/Transports/Fizzy")]
 public class FizzySteamyMirror : Transport
 {
     protected FizzySteam.Client client = new FizzySteam.Client();


### PR DESCRIPTION
After you get content posted into the help doc page you can merge this change which will make the little help icon on the component take users directly to the doc page.

We've put these on everything in Mirror that is a component.