### PR TITLE
Restructure and improve readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,20 @@ Both of these projects need to be installed and working before you can use this 
 If you know a better way around this please make a [Issue ticket.](https://github.com/Raystorms/FizzySteamyMirror/issues)**
 
 ## Host
-To be able to have your game working you need to make sure you have steam running. 
+To be able to have your game working you need to make sure you have steam running in the background. 
 **Note: You can also run it in Unity**
 
 1. Host your game
 2. if it says your playing **"Spacewar"** in Steam **congrats its working!**
 
 ## Client
+Before sending your game to your buddy make sure you have your **steamID64** ready. To find your **steamID64** goto **[Steamid.io](https://steamid.io/lookup)** and enter your steam profile URL.
+
 1. Send the game to your buddy.
-2. The client needs the **steam64id** of the host to be able to connect.
-3. Place the steam64id into **"localhost"** then click **"Lan Client"**
-4. **Bing bash bong DONE!**
+2. Your buddy needs your **steamID64** to be able to connect.
+3. Place the **steamID64** into **"localhost"** then click **"Lan Client"**
+5. Then they will be connected to you.
 
 ## Testing your game locally
 
-You cant connect to yourself locally while using **FizzySteamyMirror**. If you want to test your game locally you'll have to use **"Telepathy Transport"** instead of **"Fizzy Steamy Mirror"**.
+You cant connect to yourself locally while using **FizzySteamyMirror** since it's using steams P2P. If you want to test your game locally you'll have to use **"Telepathy Transport"** instead of **"Fizzy Steamy Mirror"**.

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ Both of these projects need to be installed and working before you can use this 
 If you know a better way around this please make a [Issue ticket.](https://github.com/Raystorms/FizzySteamyMirror/issues)**
 
 ## Host
-1. Open your game through Steam
-2. Host your game
-3. if it says your playing **"Spacewar"** in Steam **congrats its working!**
+To be able to have your game working you need to make sure you have steam running. 
+**Note: You can also run it in Unity**
 
-**Note: You can run it in Unity aswell**
+1. Host your game
+2. if it says your playing **"Spacewar"** in Steam **congrats its working!**
 
 ## Client
 1. Send the game to your buddy.
-2. The client needs the steam64id of the host to be able to connect.
+2. The client needs the **steam64id** of the host to be able to connect.
 3. Place the steam64id into **"localhost"** then click **"Lan Client"**
 4. **Bing bash bong DONE!**
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Both of these projects need to be installed and working before you can use this 
 1. Download and install the dependencies **Download the unitypackage from release for easy all in one**
 2. Download **"FizzySteamyMirror"** and place in your Assets folder somewhere. **If errors occur, open a [Issue ticket.](https://github.com/FizzCube/FizzySteamyMirror/issues)**
 3. In your NetworkManager object replace Telepathy (or any other active transport) with FizzySteamyMirror.
+4. Create a empty object in your scene and attach the **"Steam Manager"** script to it.
 
 ## Building
 1. When Building your game you have to place **"steam_appid.txt"** into the directory of the game. If you cant find it well, just make a **"steam_appid.txt"** and place **480** in side.

--- a/README.md
+++ b/README.md
@@ -1,54 +1,49 @@
 # FizzySteamyMirror
 
-Fizzcube bringing together [Steam](https://store.steampowered.com/) and [Mirror](https://github.com/vis2k/Mirror)
+This is a community maintained repo forked from [FizzCube](https://github.com/FizzCube/FizzySteamyMirror). Mirror [docs](https://mirror-networking.com/docs/Transports/Fizzy.html).
 
-This project was previously called **"SteamNetNetworkTransport"**, this is Version 2 it's a complete rebuild utilising Async of a Steam P2P network transport layer for [Mirror](https://github.com/vis2k/Mirror)
+FizzySteamyMirror brings together [Steam](https://store.steampowered.com/) and [Mirror](https://github.com/vis2k/Mirror) utilising Async of a Steam P2P network transport layer for **Mirror**.
 
 ## Dependencies
+If you want an easy import, skip the steps bellow & download the **[unitypackage](https://github.com/Raystorms/FizzySteamyMirror/releases)**, it has Steamworks.Net already included. 
+
+**Note: If you already have Steamworks.Net in your project, you might need to delete either your import or the one included in the release.**
+
 Both of these projects need to be installed and working before you can use this transport.
 1. [Steamworks.NET](https://github.com/rlabrecque/Steamworks.NET) FizzySteamyMirror relies on Steamworks.NET to communicate with the [Steamworks API](https://partner.steamgames.com/doc/sdk). **Requires .Net 4.x**  
-**Note : If you get the package from Release, Steamworks.NET is already included, you don't have to download it separately**
 2. [Mirror](https://github.com/vis2k/Mirror) FizzySteamyMirror is also obviously dependant on Mirror which is a streamline, bug fixed, maintained version of UNET for Unity. **Recommended [Stable Version](https://assetstore.unity.com/packages/tools/network/mirror-129321)**
 
 ## Setting Up
-* Note: if you want an easy import, skip the steps bellow & take the [release](https://github.com/Raystorms/FizzySteamyMirror/releases), it has Steamworks.Net already included. (if you already have Steamworks.Net in your project, you might need to delete either your import or the one included in the release).
 
-1. Download and install the dependencies **Download the unitypackage from release for easy all in one**
-2. Download **"FizzySteamyMirror"** and place in your Assets folder somewhere. **If errors occur, open a [Issue ticket.](https://github.com/FizzCube/FizzySteamyMirror/issues)**
-3. In your NetworkManager object replace Telepathy (or any other active transport) with FizzySteamyMirror.
-4. Create a empty object in your scene and attach the **"Steam Manager"** script to it.
+1. install the dependencies **[Download the unitypackage](https://github.com/Raystorms/FizzySteamyMirror/releases)**
+2. Create a empty object in your scene and attach the **"Steam Manager"** script to it.
+3. In your **"NetworkManager"** object replace **"Telepathy"** script with **"FizzySteamyMirror"** script.
 
 ## Building
 1. When Building your game you have to place **"steam_appid.txt"** into the directory of the game. If you cant find it well, just make a **"steam_appid.txt"** and place **480** in side.
 
-2. When running the game make sure you have placed it into steam as a **Non-Steam Game**
-**Note: This is not reuired, but some have reported their steam SDK not working without doing this**
+2. When running the game make sure you have placed it into steam as a **Non-Steam Game** **Note: This is not required, but some have reported their steam SDK not working without doing this.**
 
-**Note: The 480(Spacewar) appid is a very grey area, technically, it's not allowed but they don't really do anything about it.
-If you know a better way around this please make a [Issue ticket.](https://github.com/FizzCube/FizzySteamyMirror/issues)**
-
-**Note: When you have your own appid from steam then replace the 480 with your own game appid.**
+**Note: The 480(Spacewar) appid is a very grey area, technically, it's not allowed but they don't really do anything about it. When you have your own appid from steam then replace the 480 with your own game appid.
+If you know a better way around this please make a [Issue ticket.](https://github.com/Raystorms/FizzySteamyMirror/issues)**
 
 ## Host
 1. Open your game through Steam
-2. Host your game through the NetworkManagerHUD
-3. if it says your playing **"Spacewar"** in Steam **"congrats its working!"**
+2. Host your game
+3. if it says your playing **"Spacewar"** in Steam **congrats its working!**
 
 **Note: You can run it in Unity aswell**
 
 ## Client
 1. Send the game to your buddy.
 2. The client needs the steam64id of the host to be able to connect.
-3. Place the steam64id into the address of NetworkManagerHUD then click "Lan Client"
+3. Place the steam64id into **"localhost"** then click **"Lan Client"**
 4. **Bing bash bong DONE!**
-
-**Joining through code is the same like any other transport in mirror, just pass the steam64id as the address**
 
 ## Play Testing your game locally
 
-1.You need to have both scripts **"Fizzy Steamy Mirror"** and **"Telepathy Transport"**
+1. You need to have both scripts **"Fizzy Steamy Mirror"** and **"Telepathy Transport"**
 
-2.To test it locally disable **"Fizzy Steamy Mirror"** and enable **"Telepathy Transport"**
+2. To test it locally disable **"Fizzy Steamy Mirror"** and enable **"Telepathy Transport"**
 
-3.To test it on Steam P2P again enable **"Fizzy Steamy Mirror"** and disable **"Telepathy Transport"**
-
+3. To test it on Steam P2P again enable **"Fizzy Steamy Mirror"** and disable **"Telepathy Transport"**

--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ If you know a better way around this please make a [Issue ticket.](https://githu
 3. Place the steam64id into **"localhost"** then click **"Lan Client"**
 4. **Bing bash bong DONE!**
 
-## Play Testing your game locally
+## Testing your game locally
 
-1. You need to have both scripts **"Fizzy Steamy Mirror"** and **"Telepathy Transport"**
-
-2. To test it locally disable **"Fizzy Steamy Mirror"** and enable **"Telepathy Transport"**
-
-3. To test it on Steam P2P again enable **"Fizzy Steamy Mirror"** and disable **"Telepathy Transport"**
+You cant connect to yourself locally while using **FizzySteamyMirror**. If you want to test your game locally you'll have to use **"Telepathy Transport"** instead of **"Fizzy Steamy Mirror"**.


### PR DESCRIPTION
### Add step 4

I was having this issues `STEAM NOT Initialized so couldnt integrate with P2P` I could't figure out what was going on and how to solve it, but I discovered someone else was having the same issues as me on the community Mirror discord.

@Raystorms 
```
@NightDuty do you have a "Steam Manager" prefab in scene?
if not, you could add it to your scene (keep in mind that is a singleton and it persist through scenes)
"Steam Manager" is the base steam initializer for Steamworks.Net, it initializes all the steam related stuff
```
Since this is a needed step, I thought I would add it to the **Setting Up** list so everybody else wont have the same issues.

### Restructure readme.md
I thought I would improve it while I had the chance. Hopefully it should be more clear to read and follow.